### PR TITLE
Add logfile to gitignore

### DIFF
--- a/server/.env
+++ b/server/.env
@@ -1,2 +1,0 @@
-MONGO_DB=mongodb://localhost:27017/the_survey
-PORT=3005

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -21,5 +21,6 @@ yarn-debug.log*
 yarn-error.log*
 
 .env
+logfile.log
 
 /.idea


### PR DESCRIPTION
I think that this file should be untracked because if someone locally connect with mLab database then in the logfile.log this line will be added:
{"level":"info","message":"Connected to mongodb://<user>:<password>@ds151602.mlab.com:51602/survey-team-3...","timestamp":"2018-09-13T10:33:13.849Z"}
So then credentials will be publicly visible in the repository